### PR TITLE
Custom Cipher Suite For Redis SSL Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /*.pc
 *.dSYM
 tags
+*.swp
+*.un~

--- a/hiredis_ssl.h
+++ b/hiredis_ssl.h
@@ -58,7 +58,8 @@ typedef enum {
     REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED,      /* Failed to load client certificate */
     REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED,      /* Failed to load private key */
     REDIS_SSL_CTX_OS_CERTSTORE_OPEN_FAILED,     /* Failed to open system certifcate store */
-    REDIS_SSL_CTX_OS_CERT_ADD_FAILED            /* Failed to add CA certificates obtained from system to the SSL context */
+    REDIS_SSL_CTX_OS_CERT_ADD_FAILED,           /* Failed to add CA certificates obtained from system to the SSL context */
+    REDIS_SSL_CTX_CIPHER_SUITE_SET_FAILED       /* Failed to set custom cipher suite */
 } redisSSLContextError;
 
 /**
@@ -105,6 +106,20 @@ redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *
  * Free a previously created OpenSSL context.
  */
 void redisFreeSSLContext(redisSSLContext *redis_ssl_ctx);
+
+
+/**
+ * Helper function to set custom cipher suite on SSL context.
+ *
+ * cipher_suite is a string in the form of ECDHE+AESGCM:ECDHE+CHACHA20:+AES128
+ *
+ * If error is non-null, it will be populated in case the ciphers setting fails.
+ *
+ * Returne REDIS_ERR in case of an error
+ *
+ */
+int redisSetCiphersSSLContext(const char* cipher_suite, redisSSLContext* redis_ssl_ctx, redisSSLContextError* error);
+
 
 /**
  * Initiate SSL on an existing redisContext.

--- a/ssl.c
+++ b/ssl.c
@@ -187,6 +187,8 @@ const char *redisSSLContextGetError(redisSSLContextError error)
             return "Failed to open system certifcate store";
         case REDIS_SSL_CTX_OS_CERT_ADD_FAILED:
             return "Failed to add CA certificates obtained from system to the SSL context";
+        case REDIS_SSL_CTX_CIPHER_SUITE_SET_FAILED:
+            return "Failed to set the custom cipher suite on the SSL context";
         default:
             return "Unknown error code";
     }
@@ -298,6 +300,25 @@ error:
 #endif
     redisFreeSSLContext(ctx);
     return NULL;
+}
+
+
+int redisSetCiphersSSLContext(const char* cipher_suite, redisSSLContext* redis_ssl_ctx, redisSSLContextError* error)
+{
+  if(!cipher_suite || !redis_ssl_ctx)
+  {
+    return REDIS_ERR;
+  }
+
+  static const int success = 1;
+  int result = SSL_CTX_set_cipher_list(redis_ssl_ctx->ssl_ctx, cipher_suite);
+  if(result != success)
+  {
+    if(error) *error = REDIS_SSL_CTX_CIPHER_SUITE_SET_FAILED;
+    return REDIS_ERR;
+  }
+
+  return REDIS_OK;
 }
 
 /**

--- a/ssl.c
+++ b/ssl.c
@@ -372,7 +372,6 @@ static int redisSSLConnect(redisContext *c, SSL *ssl) {
     }
 
     hi_free(rssl);
-    SSL_free(ssl);
     return REDIS_ERR;
 }
 
@@ -414,7 +413,12 @@ int redisInitiateSSLWithContext(redisContext *c, redisSSLContext *redis_ssl_ctx)
         }
     }
 
-    return redisSSLConnect(c, ssl);
+    if(redisSSLConnect(c, ssl) != REDIS_OK)
+    {
+      goto error;
+    }
+
+    return REDIS_OK;
 
 error:
     if (ssl)


### PR DESCRIPTION
# What Does This PR Do?

In corporate environments with good InfoSec teams there exist pretty stringent rules on security. Some of those rules dictate what cipher suites are considered safe, and must be enforced. This PR allows the hiredis users to set the custom cipher suite.

In addition, I borrowed an improvement on the better SSL memory leak fix from the user Hans Zandbelt. He has a PR open for it here #939. I am including his fix because I don't expect a release any time soon, and I need those fixes in my code base.

